### PR TITLE
Just a quick bug fix for people using nfs.  

### DIFF
--- a/maxmind-geolite-update.py
+++ b/maxmind-geolite-update.py
@@ -8,6 +8,7 @@ import ConfigParser
 import datetime
 import urllib2
 import gzip
+import shutil
 
 __author__ = "Alex Dean"
 __copyright__ = "Copyright 2012, Psychic Bazaar Ltd"
@@ -69,7 +70,7 @@ def controller():
 
             # Finally move the unzipped file, overwriting the old one
             final_file = os.path.join(destination_dir, local_file)
-            os.rename(unzipped_file, final_file)
+            shutil.move(unzipped_file, final_file)
 
             # Created notification message, print and send to HipChat if poss
             notification = "Updated MaxMind database file %s" % final_file


### PR DESCRIPTION
os.move does not work out so well if you are using an NFS Mount for your destination dir.  This update just changes that to shutil.move
